### PR TITLE
fix ReferenceError: arg is not defined in command logRaw

### DIFF
--- a/bin/node_modules/alex-logger/index.js
+++ b/bin/node_modules/alex-logger/index.js
@@ -31,7 +31,7 @@ module.exports = function AlexLogger(dispatch) {
 		command.message(`Server packet logging is now ${logS ? 'enabled' : 'disabled'}.`)
 	});
 	
-	command.add('logRaw', () => {
+	command.add('logRaw', (arg) => {
 		arg = ''+arg
 		arg = arg.toLowerCase()
 		


### PR DESCRIPTION
oh i found it's a duplicate of https://github.com/beng-mods/opcodes-4-dummies/pull/5
sorry!

```
ReferenceError: arg is not defined
    at String.AlexLogger.command.add (C:\Packages\tera-proxy\bin\node_modules\alex-logger\index.js:35:12)
    at CommandBase.exec (C:\Packages\tera-proxy\bin\node_modules\command\index.js:119:7)
    at hookCommand (C:\Packages\tera-proxy\bin\node_modules\command\index.js:58:15)
    at Object.CommandBase.mod.hook.event [as callback] (C:\Packages\tera-proxy\bin\node_modules\command\index.js:68:17)
    at Dispatch.handle (C:\Packages\tera-proxy\node_modules\tera-proxy-game\lib\connection\dispatch\index.js:579:27)
    at Socket.RealClient.socket.on (C:\Packages\tera-proxy\node_modules\tera-proxy-game\lib\clients\RealClient.js:38:31)
    at Socket.emit (events.js:182:13)
    at addChunk (_stream_readable.js:283:12)
    at readableAddChunk (_stream_readable.js:264:11)
    at Socket.Readable.push (_stream_readable.js:219:10)
```